### PR TITLE
Compatibility with Windows/LEd (Latex Editor)/PSTricks/pdflatex

### DIFF
--- a/packages/thesis.sty
+++ b/packages/thesis.sty
@@ -13,7 +13,10 @@
 \usepackage[dvips]{graphicx} 
 % This allows for creating and manipulating graphics.
 
-\usepackage{pstricks,pst-node,pst-tree} 
+% Scott - For Windows and LEd compatibitility, PSTricks was separated from the node and tree packages, and [pdf] was added (so pdflatex command can compile). Also, auto-pst-pdf allows postscript-to-pdf conversion of the tree- creating macros mentioned below. See this thread for more info: http://tex.stackexchange.com/questions/8413/how-to-use-pstricks-in-pdflatex
+\usepackage[pdf]{pstricks}
+\usepackage[off]{auto-pst-pdf}
+\usepackage{pst-node,pst-tree} 
 
 % This allows for tree- creating macros
 % from the pstricks graphics package.


### PR DESCRIPTION
Modified the usepackage's for compatibility with pdflatex command. Specifically, PSTricks breaks when using pdflatex. Implemented some fixes to try and please both types of users (pdflatex and pslatex(?)).  Please compile on your systems to confirm I didn't break your workflows, as I don't use the latter.  

Errors from LEd:

![error_msg](https://f.cloud.github.com/assets/1906220/300450/85c647fa-9598-11e2-887d-6bdc8fe355cf.jpg)

After adding auto-ps-pdf package:

![error_msg_2](https://f.cloud.github.com/assets/1906220/300451/85cf8c3e-9598-11e2-9912-9663f2881218.png)
