### PR TITLE
List of Tables/Figures Spacing Error

### DIFF
--- a/packages/unccspecs.sty
+++ b/packages/unccspecs.sty
@@ -410,8 +410,8 @@ REFERENCES
 % This redefines the table of contents title.
 \renewcommand*{\contentsname}{TABLE OF CONTENTS}
 
-\renewcommand*{\listtablename}{LIST OF TABLES \addcontentsline{toc}{bodychapter}{LIST OF TABLES}}
-\renewcommand*{\listfigurename}{LIST OF FIGURES \addcontentsline{toc}{bodychapter}{LIST OF FIGURES}}
+\renewcommand*{\listtablename}{LIST OF TABLES \vspace*{2ex}\addcontentsline{toc}{bodychapter}{LIST OF TABLES}}
+\renewcommand*{\listfigurename}{LIST OF FIGURES \vspace*{2ex}\addcontentsline{toc}{bodychapter}{LIST OF FIGURES}}
 
 
 


### PR DESCRIPTION
The distance between the title of List of Figures/Tables is supposed to two single spaces, the same as the abstract. It was not.
