### PR TITLE
References Title Spacing too large

### DIFF
--- a/packages/unccspecs.sty
+++ b/packages/unccspecs.sty
@@ -387,7 +387,7 @@ ABSTRACT\\
 % The following commands will be used for formatting the bibliography.
 \renewcommand*{\refname}{
 REFERENCES
-\vspace{\baselineskip}
+\vspace{2ex}
 \vspace{\baselineskip}
 }
 


### PR DESCRIPTION
The original spacing was two, \vspace{\baselineskip} but this spacing was too large. The spacing used now is accurate.
