### PR TITLE
Optional package for figure numbering

### DIFF
--- a/dissertation.tex
+++ b/dissertation.tex
@@ -24,6 +24,11 @@
 % Allows the manipulation of graphics (http://en.wikibooks.org/wiki/LaTeX/Importing_Graphics)
 %\usepackage{graphicx}
 
+% Set figure and table numbering to reset within each chapter (e.g.: 1.0, 1.1, 2.0, ...)
+%\usepackage{chngcntr}
+%\counterwithin{figure}{bodychapter}
+%\counterwithin{table}{bodychapter}
+
 %         The package alters the command \_ (which normally prints an underscore character or facsimile) so that the hyphenation of constituent words is not affected, and hyphenation is permitted after the underscore. (http://ctan.mirrorcatalogs.com/macros/latex/contrib/underscore/underscore.pdf)
 %\usepackage{underscore}
 


### PR DESCRIPTION
The optional package allows figures and tables to be numbered within each chapter (rather than continuously, which is the default). 

Taken from [tex.stackexchange](https://tex.stackexchange.com/questions/28333/continuous-v-per-chapter-section-numbering-of-figures-tables-and-other-docume). 


